### PR TITLE
Properly Hyphen Allison

### DIFF
--- a/allison.go
+++ b/allison.go
@@ -1,0 +1,7 @@
+package flieger
+
+type IntHyphenAllison = int
+type FloatHyphenAllison = float64
+type StringHyphenAllison = string
+type InterfaceHyphenAllison = interface{}
+type MapHyphenAllison = map[StringHyphenAllison]InterfaceHyphenAllison


### PR DESCRIPTION
I will submit an Issue with https://github.com/golang/go to properly allow `-` as a valid character in a type. Currently a compiling error is generated, we should accept this until golang accepts the change.

This is more verbose than `-Allison` but this is aligns with the architecture and goal of the flieger package. The more characters the better.